### PR TITLE
[TASK] Add  tag to composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -28,6 +28,9 @@
     "conflict": {
         "phpunit/phpunit": "<4.8.35|<5.4.3,>=5.0"
     },
+    "replace": {
+        "symfony/var-dumper": "4.*"
+    },
     "suggest": {
         "ext-iconv": "To convert non-UTF-8 strings to UTF-8 (or symfony/polyfill-iconv in case ext-iconv cannot be used).",
         "ext-intl": "To show region name in time zone dump",


### PR DESCRIPTION
This defines the library as replacement for
symfony/var-dumper in terms of composer in order
to avoid version clashes.
See also https://getcomposer.org/doc/04-schema.md#replace.