### PR TITLE
[TASK] Introduce some more PHP version compatibility

### DIFF
--- a/Caster/ReflectionCaster.php
+++ b/Caster/ReflectionCaster.php
@@ -233,8 +233,11 @@ class ReflectionCaster
             'allowsNull' => 'allowsNull',
         ));
 
-        if ($v = $c->getType()) {
-            $a[$prefix.'typeHint'] = $v->getName();
+        if (\PHP_VERSION_ID >= 70000 && $v = $c->getType()) {
+            $a[$prefix.'typeHint'] =
+                \PHP_VERSION_ID >= 70100
+                    ? $v->getName()
+                    : (string) $v;
         }
 
         if (isset($a[$prefix.'typeHint'])) {


### PR DESCRIPTION
Guards a usage of `\ReflectionParameter::getType` which is
only available since PHP 7.0 as well as `\ReflectionType::getName`
which is only available since PHP 7.1 and adds wrapper accordingly.

Edit: this actually would fix #1 apparently, just saw that one by coincidence.